### PR TITLE
Adding DRC (Wii U GamePad) support to Not64 (basing in FIX94's work) (experimental, needs testing)

### DIFF
--- a/Makefile.menu2_wii
+++ b/Makefile.menu2_wii
@@ -5,7 +5,7 @@ CXX		=powerpc-eabi-g++
 AS		=powerpc-eabi-as
 
 CFLAGS  = -pipe -Ofast -Wall -Wno-multichar -mrvl -fgnu89-inline -flto=jobserver \
-	  -DWII -DRELEASE -DMENU_V2 -D__wii__ -DGLN64_GX -DUSE_EXPANSION \
+	  -DWII -DRELEASE -DMENU_V2 -D__wii__ -DRVL_LIBWIIDRC -DGLN64_GX -DUSE_EXPANSION \
 	  -DPPC_DYNAREC -DUSE_RECOMP_CACHE -DFASTMEM -DNDEBUG
 
 LDFLAGS	=$(CFLAGS) -Wl,-Map,$(notdir $@).map -Wl,--cref

--- a/Makefile.menu2_wii
+++ b/Makefile.menu2_wii
@@ -96,6 +96,7 @@ OBJ_INPUT	=gc_input/main.o \
 		gc_input/controller-GC.o \
 		gc_input/controller-Extenmote.o \
 		gc_input/controller-Classic.o \
+		gc_input/controller-DRC.o \
 		gc_input/controller-WiimoteNunchuk.o
 
 OBJ_RSPHLE	=rsp_hle/alist.o \
@@ -163,7 +164,7 @@ HEADER		=main/rom.h \
 		r4300/recomp.h \
 		gc_memory/pif.h
 
-LIB		=	-laesnd -lwiiuse -lbte -ltinysmb -lfat -lz -static
+LIB		=	-laesnd -lwiiuse -lbte -ltinysmb -lfat -lwiidrc -lz -static
 
 ifeq ($(strip mupen64_GX_gfx/main.cpp),)
 	export LD	:=	$(CC)

--- a/Makefile.menu2_wii
+++ b/Makefile.menu2_wii
@@ -5,7 +5,7 @@ CXX		=powerpc-eabi-g++
 AS		=powerpc-eabi-as
 
 CFLAGS  = -pipe -Ofast -Wall -Wno-multichar -mrvl -fgnu89-inline -flto=jobserver \
-	  -DWII -DRELEASE -DMENU_V2 -DGLN64_GX -DUSE_EXPANSION \
+	  -DWII -DRELEASE -DMENU_V2 -D__wii__ -DGLN64_GX -DUSE_EXPANSION \
 	  -DPPC_DYNAREC -DUSE_RECOMP_CACHE -DFASTMEM -DNDEBUG
 
 LDFLAGS	=$(CFLAGS) -Wl,-Map,$(notdir $@).map -Wl,--cref

--- a/gc_input/controller-DRC.c
+++ b/gc_input/controller-DRC.c
@@ -1,0 +1,233 @@
+/*
+ * Not64 - controller-DRC.c (based in controller-Classic.c)
+ * Original from emu_kidid (imported by saulfabreg)
+ * Copyright (c) 2013 Extrems <metaradil@gmail.com>
+ *
+ * This file is part of Not64.
+ *
+ * Not64 is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Not64 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with Not64; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <string.h>
+#include <math.h>
+#include "controller.h"
+#include <wiidrc/wiidrc.h>
+
+#define DRC_DEADZONE 6
+#define _DRC_BUILD_TMPSTICK(inval) \
+	tmp_stick16 = (inval*1.08f); \
+	if(tmp_stick16 > DRC_DEADZONE) tmp_stick16 = (tmp_stick16-DRC_DEADZONE)*1.08f; \
+	else if(tmp_stick16 < -DRC_DEADZONE) tmp_stick16 = (tmp_stick16+DRC_DEADZONE)*1.08f; \
+	else tmp_stick16 = 0; \
+	if(tmp_stick16 > 80) tmp_stick8 = 80; \
+	else if(tmp_stick16 < -80) tmp_stick8 = -80; \
+	else tmp_stick8 = (s8)tmp_stick16;
+
+static int getDRCValue(int in)
+{
+	//do scale, deadzone and clamp
+	s8 tmp_stick8; s16 tmp_stick16;
+	_DRC_BUILD_TMPSTICK(in);
+	return tmp_stick8;
+}
+
+enum {
+	L_STICK_AS_ANALOG = 1, R_STICK_AS_ANALOG = 2,
+};
+
+enum {
+	L_STICK_L = 0x01 << 16,
+	L_STICK_R = 0x02 << 16,
+	L_STICK_U = 0x04 << 16,
+	L_STICK_D = 0x08 << 16,
+	R_STICK_L = 0x10 << 16,
+	R_STICK_R = 0x20 << 16,
+	R_STICK_U = 0x40 << 16,
+	R_STICK_D = 0x80 << 16,
+};
+
+static button_t buttons[] = {
+	{  0, ~0,                         "None" },
+	{  1, WIIDRC_BUTTON_UP,     "D-Up" },
+	{  2, WIIDRC_BUTTON_LEFT,   "D-Left" },
+	{  3, WIIDRC_BUTTON_RIGHT,  "D-Right" },
+	{  4, WIIDRC_BUTTON_DOWN,   "D-Down" },
+	{  5, WIIDRC_BUTTON_L, "L" },
+	{  6, WIIDRC_BUTTON_R, "R" },
+	{  7, WIIDRC_BUTTON_ZL,     "Left Z" },
+	{  8, WIIDRC_BUTTON_ZR,     "Right Z" },
+	{  9, WIIDRC_BUTTON_A,      "A" },
+	{ 10, WIIDRC_BUTTON_B,      "B" },
+	{ 11, WIIDRC_BUTTON_X,      "X" },
+	{ 12, WIIDRC_BUTTON_Y,      "Y" },
+	{ 13, WIIDRC_BUTTON_PLUS,   "+" },
+	{ 14, WIIDRC_BUTTON_MINUS,  "-" },
+	{ 15, WIIDRC_BUTTON_HOME,   "Home" },
+	{ 16, R_STICK_U,                  "RS-Up" },
+	{ 17, R_STICK_L,                  "RS-Left" },
+	{ 18, R_STICK_R,                  "RS-Right" },
+	{ 19, R_STICK_D,                  "RS-Down" },
+	{ 20, L_STICK_U,                  "LS-Up" },
+	{ 21, L_STICK_L,                  "LS-Left" },
+	{ 22, L_STICK_R,                  "LS-Right" },
+	{ 23, L_STICK_D,                  "LS-Down" },
+};
+
+static button_t analog_sources[] = {
+	{ 0, L_STICK_AS_ANALOG,  "Left Stick" },
+	{ 1, R_STICK_AS_ANALOG,  "Right Stick" },
+};
+
+static button_t menu_combos[] = {
+	{ 0, WIIDRC_BUTTON_X|WIIDRC_BUTTON_Y, "X+Y" },
+	{ 1, WIIDRC_BUTTON_ZL|WIIDRC_BUTTON_ZR, "ZL+ZR" },
+};
+
+static unsigned int getButtons()
+{
+	const struct WiiDRCData *data = WiiDRC_Data();
+
+	unsigned int b = data->button;
+
+	if(data->xAxisL < -20) b |= L_STICK_L;
+	if(data->xAxisL >  20) b |= L_STICK_R;
+	if(data->yAxisL >  20) b |= L_STICK_U;
+	if(data->yAxisL < -20) b |= L_STICK_D;
+
+	if(data->xAxisR < -20) b |= R_STICK_L;
+	if(data->xAxisR >  20) b |= R_STICK_R;
+	if(data->yAxisR >  20) b |= R_STICK_U;
+	if(data->yAxisR < -20) b |= R_STICK_D;
+	
+	return b;
+}
+
+static int available(int Control) {
+	if(Control == 0 && WiiDRC_Inited() && WiiDRC_Connected())
+	{
+		controller_DRC.available[Control] = 1;
+		return 1;
+	}
+	else
+	{
+		controller_DRC.available[Control] = 0;
+		return 0;
+	}
+}
+
+static int _GetKeys(int Control, BUTTONS * Keys, controller_config_t* config)
+{
+	if(drcNeedScan){ WiiDRC_ScanPads(); drcNeedScan = 0; }
+	BUTTONS* c = Keys;
+	memset(c, 0, sizeof(BUTTONS));
+
+	// Only use a connected classic controller
+	if(!available(Control))
+		return 0;
+
+	unsigned int b = getButtons();
+	inline int isHeld(button_tp button){
+		return (b & button->mask) == button->mask;
+	}
+	
+	c->R_DPAD       = isHeld(config->DR);
+	c->L_DPAD       = isHeld(config->DL);
+	c->D_DPAD       = isHeld(config->DD);
+	c->U_DPAD       = isHeld(config->DU);
+	
+	c->START_BUTTON = isHeld(config->START);
+	c->B_BUTTON     = isHeld(config->B);
+	c->A_BUTTON     = isHeld(config->A);
+
+	c->Z_TRIG       = isHeld(config->Z);
+	c->R_TRIG       = isHeld(config->R);
+	c->L_TRIG       = isHeld(config->L);
+
+	c->R_CBUTTON    = isHeld(config->CR);
+	c->L_CBUTTON    = isHeld(config->CL);
+	c->D_CBUTTON    = isHeld(config->CD);
+	c->U_CBUTTON    = isHeld(config->CU);
+
+	if(config->analog->mask == L_STICK_AS_ANALOG){
+		c->X_AXIS = getDRCValue(WiiDRC_lStickX());
+		c->Y_AXIS = getDRCValue(WiiDRC_lStickY());
+	} else if(config->analog->mask == R_STICK_AS_ANALOG){
+		c->X_AXIS = getDRCValue(WiiDRC_rStickX());
+		c->Y_AXIS = getDRCValue(WiiDRC_rStickY());
+	}
+	if(config->invertedY) c->Y_AXIS = -c->Y_AXIS;
+
+	// Return whether the exit button(s) are pressed
+	return isHeld(config->exit);
+}
+
+static void pause(int Control){ }
+
+static void resume(int Control){ }
+
+static void rumble(int Control, int rumble){ }
+
+static void configure(int Control, controller_config_t* config){
+	// Don't know how this should be integrated
+}
+
+static void assign(int p, int v){
+	// TODO: Light up the LEDs appropriately
+}
+
+static void refreshAvailable(void);
+
+controller_t controller_DRC =
+	{ 'D',
+	  _GetKeys,
+	  configure,
+	  assign,
+	  pause,
+	  resume,
+	  rumble,
+	  refreshAvailable,
+	  {0, 0, 0, 0},
+	  sizeof(buttons)/sizeof(buttons[0]),
+	  buttons,
+	  sizeof(analog_sources)/sizeof(analog_sources[0]),
+	  analog_sources,
+	  sizeof(menu_combos)/sizeof(menu_combos[0]),
+	  menu_combos,
+	  { .DU        = &buttons[1],  // D-Pad Up
+	    .DL        = &buttons[2],  // D-Pad Left
+	    .DR        = &buttons[3],  // D-Pad Right
+	    .DD        = &buttons[4],  // D-Pad Down
+	    .Z         = &buttons[7],  // Left Z
+	    .L         = &buttons[5],  // Left Trigger
+	    .R         = &buttons[6],  // Right Trigger
+	    .A         = &buttons[9],  // A
+	    .B         = &buttons[10], // B
+	    .START     = &buttons[13], // +
+	    .CU        = &buttons[16], // Right Stick Up
+	    .CL        = &buttons[17], // Right Stick Left
+	    .CR        = &buttons[18], // Right Stick Right
+	    .CD        = &buttons[19], // Right Stick Down
+	    .analog    = &analog_sources[0],
+	    .exit      = &menu_combos[0],
+	    .invertedY = 0,
+	  }
+	 };
+
+static void refreshAvailable(void){
+	int i;
+	for(i=0; i<4; ++i){
+		available(i);
+	}
+}

--- a/gc_input/input.c
+++ b/gc_input/input.c
@@ -38,7 +38,7 @@
 static CONTROL_INFO control_info;
 static BOOL lastData[4];
 
-virtualControllers_t virtualControllers[4];
+virtualControllers_t virtualControllers[5];
 
 controller_t* controller_ts[num_controller_t] =
 #if defined(WII) && !defined(NO_BT)
@@ -49,6 +49,7 @@ controller_t* controller_ts[num_controller_t] =
 	  &controller_ExtenmoteNES,
 	  &controller_WiiUPro,
 	  &controller_Classic,
+	  &controller_DRC,
 	  &controller_WiimoteNunchuk,
 	  &controller_Wiimote,
 	 };
@@ -335,7 +336,8 @@ EXPORT void CALL WM_KeyDown( WPARAM wParam, LPARAM lParam )
 EXPORT void CALL WM_KeyUp( WPARAM wParam, LPARAM lParam )
 {
 }
-void pauseInput(void){
+
+void pauseInput(void){
 	int i;
 	for(i=0; i<4; ++i){
 		if(virtualControllers[i].inUse){

--- a/libgui/FocusManager.h
+++ b/libgui/FocusManager.h
@@ -64,6 +64,7 @@ private:
 	int buttonsPressed, previousButtonsPressed;
 	u32 previousButtonsWii[4];
 	u16 previousButtonsGC[4];
+	u32 previousButtonsDRC[4];
 	ComponentList focusList;
 	Component *primaryFocusOwner, *secondaryFocusOwner;
 	Frame *currentFrame;

--- a/libgui/InputManager.cpp
+++ b/libgui/InputManager.cpp
@@ -22,6 +22,7 @@
 #include "FocusManager.h"
 #include "CursorManager.h"
 #include "../main/wii64config.h"
+#include <wiidrc/wiidrc.h>
 
 extern char shutdown;
 extern int stop;
@@ -40,6 +41,7 @@ Input::Input()
 	WPAD_SetVRes(WPAD_CHAN_ALL, 640, 480);
 	WPAD_SetDataFormat(WPAD_CHAN_ALL, WPAD_FMT_BTNS_ACC_IR); 
 	SYS_SetPowerCallback(PowerCallback);
+	WiiDRC_Init();
 #endif
 	SYS_SetResetCallback(ResetCallback);
 }
@@ -53,6 +55,7 @@ void Input::refreshInput()
 	PAD_ScanPads();
 #ifdef HW_RVL
 	WPAD_ScanPads();
+	if(drcNeedScan){ WiiDRC_ScanPads(); drcNeedScan = 0; }
 #endif
 }
 

--- a/libgui/InputManager.h
+++ b/libgui/InputManager.h
@@ -22,6 +22,7 @@
 #define INPUTMANAGER_H
 
 #include "GuiTypes.h"
+#include <wiidrc/wiidrc.h>
 
 namespace menu {
 

--- a/libgui/InputStatusBar.cpp
+++ b/libgui/InputStatusBar.cpp
@@ -26,6 +26,7 @@
 #include "FocusManager.h"
 #include <math.h>
 #include <gccore.h>
+#include <wiidrc/wiidrc.h>
 #include "../main/wii64config.h"
 
 extern "C" {
@@ -160,6 +161,7 @@ void InputStatusBar::drawComponent(Graphics& gfx)
 			controller_ExtenmoteNES.available[(int)padAssign[i]] = (err == WPAD_ERR_NONE && type == WPAD_EXP_NES) ? 1 : 0;
 			controller_WiiUPro.available[(int)padAssign[i]] = (err == WPAD_ERR_NONE && type == WPAD_EXP_WIIUPRO) ? 1 : 0;
 			controller_Classic.available[(int)padAssign[i]] = (err == WPAD_ERR_NONE && type == WPAD_EXP_CLASSIC) ? 1 : 0;
+			controller_DRC.available[(int)padAssign[i]] = (i == 0 && WiiDRC_Inited() && WiiDRC_Connected()) ? 1 : 0;
 			controller_WiimoteNunchuk.available[(int)padAssign[i]] = (err == WPAD_ERR_NONE && type == WPAD_EXP_NUNCHUK) ? 1 : 0;
 			controller_Wiimote.available[(int)padAssign[i]] = (err == WPAD_ERR_NONE && type == WPAD_EXP_NONE) ? 1 : 0;
 			if (controller_ExtenmoteGC.available[(int)padAssign[i]])
@@ -221,6 +223,16 @@ void InputStatusBar::drawComponent(Graphics& gfx)
 				IplFont::getInstance().drawInit(controllerColors[i]);
 				statusIcon = Resources::getInstance().getImage(Resources::IMAGE_CONTROLLER_CLASSIC);
 //				sprintf (statusText, "Pad%d: CC%d", i+1, padAssign[i]+1);
+			}
+			else if (controller_DRC.available[(int)padAssign[i]])
+			{
+				assign_controller(i, &controller_DRC, (int)padAssign[i]);
+//				gfx.setColor(activeColor);
+//				IplFont::getInstance().drawInit(activeColor);
+				gfx.setColor(controllerColors[i]);
+				IplFont::getInstance().drawInit(controllerColors[i]);
+				statusIcon = Resources::getInstance().getImage(Resources::IMAGE_CONTROLLER_CLASSIC);
+//				sprintf (statusText, "Pad%d: DRC%d", i+1, padAssign[i]+1);
 			}
 			else if (controller_WiimoteNunchuk.available[(int)padAssign[i]])
 			{

--- a/main/main_gc-menu.c
+++ b/main/main_gc-menu.c
@@ -95,6 +95,7 @@ extern timers Timers;
        char creditsScrolling;
        char padNeedScan;
        char wpadNeedScan;
+       char drcNeedScan;
        char shutdown;
 	   char saveStateDevice;
 	   char pakMode[4];
@@ -213,6 +214,20 @@ u16 readWPAD(void){
 	   	b |= (w & CLASSIC_CTRL_BUTTON_RIGHT) ? PAD_BUTTON_RIGHT : 0;
 	   	b |= (w & CLASSIC_CTRL_BUTTON_A) ? PAD_BUTTON_A : 0;
 	   	b |= (w & CLASSIC_CTRL_BUTTON_B) ? PAD_BUTTON_B : 0;
+	}
+	
+	if(drcNeedScan){ WiiDRC_ScanPads(); drcNeedScan = 0; }
+	const WiiDRCData* drc = WiiDRC_Data();
+
+	if(WiiDRC_Inited() && WiiDRC_Connected())
+	{
+	   	u16 w = drc->button;
+	   	b |= (w & WIIDRC_BUTTON_UP)    ? PAD_BUTTON_UP    : 0;
+	   	b |= (w & WIIDRC_BUTTON_DOWN)  ? PAD_BUTTON_DOWN  : 0;
+	   	b |= (w & WIIDRC_BUTTON_LEFT)  ? PAD_BUTTON_LEFT  : 0;
+	   	b |= (w & WIIDRC_BUTTON_RIGHT) ? PAD_BUTTON_RIGHT : 0;
+	   	b |= (w & WIIDRC_BUTTON_A) ? PAD_BUTTON_A : 0;
+	   	b |= (w & WIIDRC_BUTTON_B) ? PAD_BUTTON_B : 0;
 	}
 
 	return b;
@@ -382,7 +397,7 @@ static void rsp_info_init(void){
 }
 
 void ScanPADSandReset() {
-	padNeedScan = wpadNeedScan = 1;
+	drcNeedScan = padNeedScan = wpadNeedScan = 1;
 	if(!((*(u32*)0xCC003000)>>16))
 		stop = 1;
 }

--- a/menu/ConfigureButtonsFrame.cpp
+++ b/menu/ConfigureButtonsFrame.cpp
@@ -269,6 +269,8 @@ void ConfigureButtonsFrame::activateSubmenu(int submenu)
 		activePadType = ACTIVEPADTYPE_WIIUPRO;
 	else if (virtualControllers[activePad].control == &controller_Classic)
 		activePadType = ACTIVEPADTYPE_CLASSIC;
+	else if (virtualControllers[activePad].control == &controller_DRC)
+		activePadType = ACTIVEPADTYPE_CLASSIC;
 	else if (virtualControllers[activePad].control == &controller_WiimoteNunchuk)
 		activePadType = ACTIVEPADTYPE_WIIMOTENUNCHUCK;
 	else if (virtualControllers[activePad].control == &controller_Wiimote)

--- a/menu/FileBrowserFrame.cpp
+++ b/menu/FileBrowserFrame.cpp
@@ -260,6 +260,33 @@ void FileBrowserFrame::drawChildren(menu::Graphics &gfx)
 				}
 				break;
 			}
+			else if (i == 0 && WiiDRC_Inited() && WiiDRC_Connected() && (WiiDRC_ButtonsHeld() ^ previousButtonsDRC[i]))
+			{
+				u32 currentButtonsDownDRC = (WiiDRC_ButtonsHeld() ^ previousButtonsDRC[i]) & WiiDRC_ButtonsHeld();
+				previousButtonsDRC[i] = WiiDRC_ButtonsHeld();
+				if (currentButtonsDownDRC & WIIDRC_BUTTON_R)
+				{
+					//move to next set & return
+					if(current_page+1 < max_page) 
+					{
+						current_page +=1;
+						fileBrowserFrame_FillPage();
+						menu::Focus::getInstance().clearPrimaryFocus();
+					}
+					break;
+				}
+				else if (currentButtonsDownDRC & WIIDRC_BUTTON_L)
+				{
+					//move to the previous set & return
+					if(current_page > 0) 
+					{
+						current_page -= 1;
+						fileBrowserFrame_FillPage();
+						menu::Focus::getInstance().clearPrimaryFocus();
+					}
+					break;
+				}
+			}
 #endif //HW_RVL
 		}
 

--- a/menu/FileBrowserFrame.h
+++ b/menu/FileBrowserFrame.h
@@ -34,7 +34,7 @@ public:
 private:
 	u16 previousButtonsGC[4];
 	u32 previousButtonsWii[4];
-
+	u32 previousButtonsDRC[4];
 };
 
 #endif

--- a/menu/SettingsFrame.cpp
+++ b/menu/SettingsFrame.cpp
@@ -582,6 +582,31 @@ void SettingsFrame::drawChildren(menu::Graphics &gfx)
 				}
 				break;
 			}
+			else if (i == 0 && WiiDRC_Inited() && WiiDRC_Connected() && (WiiDRC_ButtonsHeld() ^ previousButtonsDRC[i]))
+			{
+				u32 currentButtonsDownDRC = (WiiDRC_ButtonsHeld() ^ previousButtonsDRC[i]) & WiiDRC_ButtonsHeld();
+				previousButtonsDRC[i] = WiiDRC_ButtonsHeld();
+				if (currentButtonsDownDRC & WIIDRC_BUTTON_R)
+				{
+					//move to next tab
+					if(activeSubmenu < SUBMENU_SAVES) 
+					{
+						activateSubmenu(activeSubmenu+1);
+						menu::Focus::getInstance().clearPrimaryFocus();
+					}
+					break;
+				}
+				else if (currentButtonsDownDRC & WIIDRC_BUTTON_L)
+				{
+					//move to the previous tab
+					if(activeSubmenu > SUBMENU_GENERAL) 
+					{
+						activateSubmenu(activeSubmenu-1);
+						menu::Focus::getInstance().clearPrimaryFocus();
+					}
+					break;
+				}
+			}
 #endif //HW_RVL
 		}
 

--- a/menu/SettingsFrame.h
+++ b/menu/SettingsFrame.h
@@ -45,7 +45,7 @@ private:
 	int activeSubmenu;
 	u16 previousButtonsGC[4];
 	u32 previousButtonsWii[4];
-
+	u32 previousButtonsDRC[4];
 };
 
 #endif


### PR DESCRIPTION
Hi there @Extrems 
As a member of GBAtemp and GitHub, i would like to contribute for the first time with Not64, with these commits i've made in the source code i will try to add DRC (Wii U GamePad) support.

These code were taken principally from @FIX94's [mupen64gc-fix94](http://github.com/FIX94/mupen64gc-fix94) (which is based in Wii64 Beta 1.1 too), using the great library libwiidrc (https://github.com/FIX94/libwiidrc).

Remember, this contribution is still experimental, so this need to be tested. If you can compile a build of Not64 with these changes for test it with another friend, I will be grateful.

EDIT: there are two extra commits for try to add of the best way the libwiidrc library usage, can you review them?

Please review these changes, and if they are sucessful, can you merge them?

Thanks, @saulfabregwiivc