### PR TITLE
Use a sleep function for try to fix input not responding. (FIX94)

### DIFF
--- a/menu/FileBrowserFrame.cpp
+++ b/menu/FileBrowserFrame.cpp
@@ -19,6 +19,7 @@
 **/
 
 #include <math.h>
+#include <unistd.h>
 #include <cstdlib>
 #include "MenuContext.h"
 #include "FileBrowserFrame.h"
@@ -470,6 +471,8 @@ void fileBrowserFrame_LoadFile(int i)
 		
 		if(!ret){	// If the read succeeded.
 			if(skipMenu){
+				// FIX94: after init wpad wait a bit
+				sleep(6);
 				pMenuContext->setActiveFrame(MenuContext::FRAME_MAIN);
 				Func_SetPlayGame();
 				Func_PlayGame();


### PR DESCRIPTION
During autoboot games using the arguments rompath and SkipMenu, most of the time the input is not responding.
Referring to some code on Wii64's fork by FIX94, this should fix the input not responding when in autoboot mode, by making it wait (sleep) for 6 (milisecs?) after WPAD gets initialized for avoid input issues.