### PR TITLE
Unbreak (fix) games which use Interlace video mode (High quality video) (FIX94)

### DIFF
--- a/glN64_GX/VI.cpp
+++ b/glN64_GX/VI.cpp
@@ -84,6 +84,10 @@ void VI_UpdateSize()
 
 	if (VI.width == 0) VI.width = 320;
 	if (VI.height == 0) VI.height = 240;
+
+	// FIX94: Interlaced video mode detection (Quake II, etc...)
+	if ((*REG.VI_STATUS>>6)&1)
+		VI.height*=2;
 }
 
 void VI_UpdateScreen()


### PR DESCRIPTION
Fixes graphical issues in Quake II, and other games which use High quality when the Expansion Pak is detected.

Courtesy of FIX94 in his fork Mupen64GC-FIX94.