### PR TITLE
Backport glN64 GX video plugin changes and fixes from Mupen64GC-FIX94.

### DIFF
--- a/glN64_GX/OpenGL.cpp
+++ b/glN64_GX/OpenGL.cpp
@@ -1154,7 +1154,6 @@ void OGL_DrawTriangles()
 	glDrawArrays( GL_TRIANGLES, 0, OGL.numVertices );
 #else // !__GX__
 	GXColor GXcol;
-	float invW;
 
 #ifdef GLN64_SDLOG
 	sprintf(txtbuffer,"OGL_DrawTris: numTri %d, numVert %d, useT0 %d, useT1 %d\n", OGL.numTriangles, OGL.numVertices, combiner.usesT0, combiner.usesT1);
@@ -1165,10 +1164,7 @@ void OGL_DrawTriangles()
 	if(OGL.GXupdateMtx)
 	{
 		OGL_UpdateViewport();
-		if(OGL.GXuseCombW)
-			GX_LoadProjectionMtx(OGL.GXcombW, GX_PERSPECTIVE);
-		else
-			GX_LoadProjectionMtx(OGL.GXprojIdent, GX_ORTHOGRAPHIC);
+		GX_LoadProjectionMtx(OGL.GXprojIdent, GX_PERSPECTIVE);
 		OGL.GXupdateMtx = false;
 	}
 
@@ -1213,21 +1209,13 @@ void OGL_DrawTriangles()
 
 
 #ifdef SHOW_DEBUG
-	if (OGL.GXuseCombW) CntTriProjW += OGL.numTriangles;
-	else CntTriOther += OGL.numTriangles;
-	if (OGL.GXuseCombW && OGL.GXuseProjWnear) CntTriNear += OGL.numTriangles;
+	CntTriOther += OGL.numTriangles;
 	if (OGL.GXpolyOffset) CntTriPolyOffset += OGL.numTriangles;
 #endif
 
 	GX_Begin(GX_TRIANGLES, GX_VTXFMT0, OGL.numVertices);
 	for (int i = 0; i < OGL.numVertices; i++) {
-		if(OGL.GXuseCombW)
-			GX_Position3f32( OGL.vertices[i].x, OGL.vertices[i].y, -OGL.vertices[i].w );
-		else
-		{
-			invW = (OGL.vertices[i].w != 0) ? 1/OGL.vertices[i].w : 0.0f;
-			GX_Position3f32( OGL.vertices[i].x*invW, OGL.vertices[i].y*invW, OGL.vertices[i].z*invW );
-		}
+		GX_Position3f32( OGL.vertices[i].x, OGL.vertices[i].y, -OGL.vertices[i].w );
 		GXcol.r = GXcastf32u8(OGL.vertices[i].color.r);
 		GXcol.g = GXcastf32u8(OGL.vertices[i].color.g);
 		GXcol.b = GXcastf32u8(OGL.vertices[i].color.b);
@@ -1290,16 +1278,12 @@ void OGL_DrawLine( SPVertex *vertices, int v0, int v1, float width )
 	GX_SetLineWidth( width * OGL.GXscaleX * 6, GX_TO_ZERO );
 
 	GXColor GXcol;
-	float invW;
 
 	//Update MV & P Matrices
 	if(OGL.GXupdateMtx)
 	{
 		OGL_UpdateViewport();
-		if(OGL.GXuseCombW)
-			GX_LoadProjectionMtx(OGL.GXcombW, GX_PERSPECTIVE);
-		else
-			GX_LoadProjectionMtx(OGL.GXprojIdent, GX_ORTHOGRAPHIC);
+		GX_LoadProjectionMtx(OGL.GXprojIdent, GX_PERSPECTIVE);
 		OGL.GXupdateMtx = false;
 	}
 
@@ -1328,13 +1312,7 @@ void OGL_DrawLine( SPVertex *vertices, int v0, int v1, float width )
 	GX_Begin(GX_LINES, GX_VTXFMT0, 2);
 		for (int i = 0; i < 2; i++)
 		{
-			if(OGL.GXuseCombW)
-				GX_Position3f32( OGL.vertices[i].x, OGL.vertices[i].y, -OGL.vertices[i].w );
-			else
-			{
-				invW = (OGL.vertices[i].w != 0) ? 1/OGL.vertices[i].w : 0.0f;
-				GX_Position3f32( OGL.vertices[i].x*invW, OGL.vertices[i].y*invW, OGL.vertices[i].z*invW );
-			}
+			GX_Position3f32( OGL.vertices[i].x, OGL.vertices[i].y, -OGL.vertices[i].w );
 			color.r = vertices[v[i]].r;
 			color.g = vertices[v[i]].g;
 			color.b = vertices[v[i]].b;

--- a/glN64_GX/OpenGL.h
+++ b/glN64_GX/OpenGL.h
@@ -116,7 +116,6 @@ struct GLInfo
 	Mtx44	GXprojIdent;
 	Mtx44	GXprojTemp;
 	Mtx		GXmodelViewIdent;
-	BOOL	GXuseCombW;
 	BOOL	GXupdateMtx;
 	int		GXnumVtxMP;
 	bool	GXuseAlphaCompare;

--- a/glN64_GX/RSP.cpp
+++ b/glN64_GX/RSP.cpp
@@ -13,6 +13,7 @@
 #include <gccore.h>
 #endif // __GX__
 
+#include <math.h>
 #ifndef __LINUX__
 # include <windows.h>
 #else
@@ -22,7 +23,7 @@
 #  define min(a,b) ((a) < (b) ? (a) : (b))
 # endif
 #endif
-#include <math.h>
+
 #include "glN64.h"
 #include "OpenGL.h"
 #include "Debug.h"
@@ -43,7 +44,9 @@ RSPInfo		RSP;
 
 void RSP_LoadMatrix( f32 mtx[4][4], u32 address )
 {
+#ifndef GEKKO
 	f32 recip = 1.5258789e-05f;
+#endif
 #ifndef __LINUX__
 	__asm {
 		mov		esi, dword ptr [RDRAM];

--- a/glN64_GX/VI.cpp
+++ b/glN64_GX/VI.cpp
@@ -84,6 +84,10 @@ void VI_UpdateSize()
 
 	if (VI.width == 0) VI.width = 320;
 	if (VI.height == 0) VI.height = 240;
+
+	// FIX94: Interlaced video mode detection (Quake II, etc...)
+	if ((*REG.VI_STATUS>>6)&1)
+		VI.height*=2;
 }
 
 void VI_UpdateScreen()

--- a/glN64_GX/gSP.cpp
+++ b/glN64_GX/gSP.cpp
@@ -125,18 +125,7 @@ void gSPCombineMatrices()
 
 	guMtx44Inverse( gSP.matrix.combined, OGL.GXprojTemp );
 
-	if (OGL.GXprojTemp[2][3] != 0.0f)
-	{
-		OGL.GXcombW[2][3] = GXprojZScale / OGL.GXprojTemp[2][3];
-		OGL.GXcombW[2][2] = -GXprojZOffset + (OGL.GXcombW[2][3] * OGL.GXprojTemp[3][3]);
-		OGL.GXuseCombW = true;
-		OGL.GXupdateMtx = true;
-	}
-	else
-	{
-		OGL.GXuseCombW = false;
-		OGL.GXupdateMtx = true;
-	}
+	OGL.GXupdateMtx = true;
 #endif //__GX__
 }
 
@@ -431,18 +420,7 @@ void gSPForceMatrix( u32 mptr )
 
 	guMtx44Inverse( gSP.matrix.combined, OGL.GXprojTemp );
 
-	if (OGL.GXprojTemp[2][3] != 0.0f)
-	{
-		OGL.GXcombW[2][3] = GXprojZScale / OGL.GXprojTemp[2][3];
-		OGL.GXcombW[2][2] = -GXprojZOffset + (OGL.GXcombW[2][3] * OGL.GXprojTemp[3][3]);
-		OGL.GXuseCombW = true;
-		OGL.GXupdateMtx = true;
-	}
-	else
-	{
-		OGL.GXuseCombW = false;
-		OGL.GXupdateMtx = true;
-	}
+	OGL.GXupdateMtx = true;
 #endif //__GX__
 
 	gSP.changed &= ~CHANGED_MATRIX;
@@ -1232,18 +1210,7 @@ void gSPInsertMatrix( u32 where, u32 num )
 
 	guMtx44Inverse( gSP.matrix.combined, OGL.GXprojTemp );
 
-	if (OGL.GXprojTemp[2][3] != 0.0f)
-	{
-		OGL.GXcombW[2][3] = GXprojZScale / OGL.GXprojTemp[2][3];
-		OGL.GXcombW[2][2] = -GXprojZOffset + (OGL.GXcombW[2][3] * OGL.GXprojTemp[3][3]);
-		OGL.GXuseCombW = true;
-		OGL.GXupdateMtx = true;
-	}
-	else
-	{
-		OGL.GXuseCombW = false;
-		OGL.GXupdateMtx = true;
-	}
+	OGL.GXupdateMtx = true;
 #endif //__GX__
 
 #ifdef DEBUG


### PR DESCRIPTION
Mupen64GC-FIX94, made by @FIX94, which is a fork of Wii64 Beta 1.1 'Honey' (like Not64 is), also had some changes in the glN64 GX code for fix various graphical issues in some games.

Respecting the current Not64 code in glN64 GX, i backported FIX94's changes here, and the results are the following games have improvements:

- **F-ZERO X:** Fixes the background flickering.
- **Zelda: Ocarina of Time:** Fixes extreme glitching in certain camera positions.
- **Wetrix:** Now makes very, very playable. The arrows now have their proper colors which is a lot better than it was before where they were completely white.
- **NFL Blitz:** Fixes various textures in the game field when in gameplay.
- **Quake II:** Fixes textures and other things. Still needs **FB textures to be turn on** for stop screen flashes.
- **Mortal Kombat 4:** The HUDs of the fighters in gameplay is now visible.
- **Mortal Kombat Mythologies: Sub-Zero:** The HUD of Sub-Zero (the player) in gameplay is now visible.

There might are other fixed games but these were the most problematic ones i've tested and they work better now.